### PR TITLE
为业务智能合约类添加常用的String类型的value的封装方法，简化业务合约编写

### DIFF
--- a/ledger-mgr-interface/src/main/java/com/jinninghui/newspiral/ledger/mgr/SmartContractMgr.java
+++ b/ledger-mgr-interface/src/main/java/com/jinninghui/newspiral/ledger/mgr/SmartContractMgr.java
@@ -16,9 +16,16 @@ public interface SmartContractMgr {
 /******************** StateStorage 的接口开始**************************/
     byte[] getState(String key);
 
+    String getStrState(String key);
+
     void insertState(String key, byte[] value);
 
+    void insertStrState(String key, String value);
+
     void updateState(String key, byte[] newValue);
+
+
+    void updateStrState(String key, String value);
 
 
 
@@ -28,6 +35,9 @@ public interface SmartContractMgr {
      * @param value
      */
     void putState(String key, byte[] value);
+
+
+    void putStrState(String key, String value);
 
     boolean existKey(String key);
 

--- a/ledger-mgr/src/main/java/com/jinninghui/newspiral/ledger/mgr/impl/SmartContractMgrImpl.java
+++ b/ledger-mgr/src/main/java/com/jinninghui/newspiral/ledger/mgr/impl/SmartContractMgrImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,9 +41,20 @@ public class SmartContractMgrImpl implements SmartContractMgr {
     }
 
     @Override
+    public String getStrState(String key) {
+        return new String(ledgerMgr.queryState(key),StandardCharsets.UTF_8);
+    }
+
+    @Override
     public void insertState(String key, byte[] value) {
         //log.info("调用智能合约插入世界状态key=" + key);
         ledgerMgr.insertState(key, value);
+    }
+
+    @Override
+    public void insertStrState(String key, String value) {
+        //log.info("调用智能合约插入世界状态key=" + key);
+        ledgerMgr.insertState(key, value.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
@@ -53,9 +65,23 @@ public class SmartContractMgrImpl implements SmartContractMgr {
     }
 
     @Override
+    public void updateStrState(String key, String newValue) {
+        ledgerMgr.updateState(key, newValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    @Override
     public void putState(String key, byte[] value) {
         //Long curr = System.currentTimeMillis();
         ledgerMgr.putState(key, value);
+        //log.info("put state time {}", System.currentTimeMillis() - curr);
+    }
+
+
+    @Override
+    public void putStrState(String key, String value) {
+        //Long curr = System.currentTimeMillis();
+        ledgerMgr.putState(key, value.getBytes(StandardCharsets.UTF_8));
         //log.info("put state time {}", System.currentTimeMillis() - curr);
     }
 

--- a/security-service/src/main/java/com/jinninghui/newspiral/security/contract/SandboxContractMgrImpl.java
+++ b/security-service/src/main/java/com/jinninghui/newspiral/security/contract/SandboxContractMgrImpl.java
@@ -9,6 +9,7 @@ import com.jinninghui.newspiral.ledger.mgr.SmartContractMgr;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -41,11 +42,36 @@ public class SandboxContractMgrImpl implements SmartContractMgr {
         return null;
     }
 
+
+    @Override
+    public String getStrState(String key) {
+        if (!Thread.interrupted()) {
+            try {
+                byte[] state =  executorTX.get().submit(() -> smartContractMgr.getState(key)).get();
+                return new String(state, StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                localHandler.get().uncaughtException(Thread.currentThread(),e);
+            }
+        }
+        return null;
+    }
+
     @Override
     public void insertState(String key, byte[] value) {
         if (!Thread.interrupted()) {
             try {
                 executorTX.get().submit(() -> smartContractMgr.insertState(key, value)).get();
+            } catch (Exception e) {
+                localHandler.get().uncaughtException(Thread.currentThread(),e);
+            }
+        }
+    }
+
+    @Override
+    public void insertStrState(String key, String value) {
+        if (!Thread.interrupted()) {
+            try {
+                executorTX.get().submit(() -> smartContractMgr.insertState(key, value.getBytes(StandardCharsets.UTF_8))).get();
             } catch (Exception e) {
                 localHandler.get().uncaughtException(Thread.currentThread(),e);
             }
@@ -63,11 +89,34 @@ public class SandboxContractMgrImpl implements SmartContractMgr {
         }
     }
 
+
+    @Override
+    public void updateStrState(String key, String newValue) {
+        if (!Thread.interrupted()) {
+            try {
+                executorTX.get().submit(() -> smartContractMgr.updateState(key, newValue.getBytes(StandardCharsets.UTF_8))).get();
+            } catch (Exception e) {
+                localHandler.get().uncaughtException(Thread.currentThread(),e);
+            }
+        }
+    }
+
     @Override
     public void putState(String key, byte[] value) {
         if (!Thread.interrupted()) {
             try {
                 executorTX.get().submit(() -> smartContractMgr.putState(key, value)).get();
+            } catch (Exception e) {
+                localHandler.get().uncaughtException(Thread.currentThread(),e);
+            }
+        }
+    }
+
+    @Override
+    public void putStrState(String key, String value) {
+        if (!Thread.interrupted()) {
+            try {
+                executorTX.get().submit(() -> smartContractMgr.putState(key, value.getBytes(StandardCharsets.UTF_8))).get();
             } catch (Exception e) {
                 localHandler.get().uncaughtException(Thread.currentThread(),e);
             }


### PR DESCRIPTION
为业务智能合约类添加常用的String类型的value的封装方法，简化业务合约编写